### PR TITLE
Update gh workflow

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -34,8 +34,9 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY . .
 
-# Build backend packages
-RUN pnpm --filter "./backend/**" run build:prod
+# Build backend packages (packages use build:prod, server app uses build)
+RUN pnpm --filter "./backend/packages/**" run build:prod && \
+    pnpm --filter "@beauty-salon-backend/server" run build
 
 # Development stage
 FROM node:24.4.0-alpine AS development
@@ -79,7 +80,8 @@ CMD ["pnpm", "--filter", "@beauty-salon-backend/server", "dev"]
 # Production stage
 FROM node:24.4.0-alpine AS production
 
-# Install pnpm globally and runtime dependencies
+# Set production environment
+ENV NODE_ENV=production
 ENV PNPM_VERSION=10.13.1
 RUN apk add --no-cache bash wget && \
     npm install -g pnpm@${PNPM_VERSION}
@@ -109,12 +111,19 @@ COPY --chown=appuser:appuser backend/apps/server/package.json ./backend/apps/ser
 # Copy specs package.json
 COPY --chown=appuser:appuser specs/package.json ./specs/
 
-# Install production dependencies only
-RUN pnpm install --prod --frozen-lockfile
+# Install production dependencies only (ignore scripts to skip husky)
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts
 
 # Copy built artifacts from builder
-COPY --from=builder --chown=appuser:appuser /app/backend/packages/*/dist ./backend/packages/*/dist/
-COPY --from=builder --chown=appuser:appuser /app/backend/apps/*/dist ./backend/apps/*/dist/
+# Each package needs to maintain its directory structure
+COPY --from=builder --chown=appuser:appuser /app/backend/packages/api/dist ./backend/packages/api/dist/
+COPY --from=builder --chown=appuser:appuser /app/backend/packages/config/dist ./backend/packages/config/dist/
+COPY --from=builder --chown=appuser:appuser /app/backend/packages/database/dist ./backend/packages/database/dist/
+COPY --from=builder --chown=appuser:appuser /app/backend/packages/domain/dist ./backend/packages/domain/dist/
+COPY --from=builder --chown=appuser:appuser /app/backend/packages/generated/dist ./backend/packages/generated/dist/
+COPY --from=builder --chown=appuser:appuser /app/backend/packages/infrastructure/dist ./backend/packages/infrastructure/dist/
+COPY --from=builder --chown=appuser:appuser /app/backend/packages/utility/dist ./backend/packages/utility/dist/
+COPY --from=builder --chown=appuser:appuser /app/backend/apps/server/dist ./backend/apps/server/dist/
 
 # Switch to non-root user
 USER appuser

--- a/Dockerfile.frontend.admin
+++ b/Dockerfile.frontend.admin
@@ -55,7 +55,7 @@ RUN pnpm generate
 RUN pnpm prepare:frontend
 
 # Build admin app for production
-RUN pnpm --filter "@beauty-salon/admin-app" build:prod
+RUN pnpm --filter "@beauty-salon-frontend/admin-app" build:prod
 
 # Stage 2: Production runtime
 FROM node:24.4.0-alpine AS runtime

--- a/Dockerfile.frontend.dashboard
+++ b/Dockerfile.frontend.dashboard
@@ -55,7 +55,7 @@ RUN pnpm generate
 RUN pnpm prepare:frontend
 
 # Build dashboard app for production
-RUN pnpm --filter "@beauty-salon/dashboard-app" build:prod
+RUN pnpm --filter "@beauty-salon-frontend/dashboard-app" build:prod
 
 # Stage 2: Production runtime
 FROM node:24.4.0-alpine AS runtime

--- a/Dockerfile.frontend.portal
+++ b/Dockerfile.frontend.portal
@@ -55,7 +55,7 @@ RUN pnpm generate
 RUN pnpm prepare:frontend
 
 # Build portal app for production
-RUN pnpm --filter "@beauty-salon/portal-app" build:prod
+RUN pnpm --filter "@beauty-salon-frontend/portal-app" build:prod
 
 # Stage 2: Production runtime
 FROM node:24.4.0-alpine AS runtime


### PR DESCRIPTION
# 🐛 Fix: Production Docker Build Failures

## 📋 問題の概要 (Problem Summary)

mainブランチへのマージ時に、production targetのDockerビルドが失敗していました。

Three critical issues were causing production Docker builds to fail:
1. Husky (dev dependency) trying to run in production
2. Incorrect package names for frontend apps
3. Build command mismatch for server app (build:prod vs build)

## 🔧 修正内容 (Changes Made)

### 1. Backend Dockerfile Fixes (`Dockerfile.backend`)

#### Issue 1: Husky in Production
**Problem**:
```
. prepare$ husky
. prepare: sh: husky: not found
ELIFECYCLE  Command failed.
```

**Solution**:
```dockerfile
# Before
RUN pnpm install --prod --frozen-lockfile

# After
RUN pnpm install --prod --frozen-lockfile --ignore-scripts
```

#### Issue 2: Build Command Mismatch
**Problem**:
- Backend packages use `build:prod` script
- Server app only has `build` script
- Using wildcard `"./backend/**"` was trying to run `build:prod` on server app

**Solution**:
```dockerfile
# Before
RUN pnpm --filter "./backend/**" run build:prod

# After
RUN pnpm --filter "./backend/packages/**" run build:prod && \
    pnpm --filter "@beauty-salon-backend/server" run build
```

#### Issue 3: Production Environment Setup
**Added**:
```dockerfile
ENV NODE_ENV=production
```

### 2. Frontend Dockerfiles Fix (All 3 frontend Dockerfiles)

**Problem**: Incorrect package names in build commands

**Solution**:
```dockerfile
# Before (incorrect)
RUN pnpm --filter "@beauty-salon/admin-app" build:prod
RUN pnpm --filter "@beauty-salon/portal-app" build:prod
RUN pnpm --filter "@beauty-salon/dashboard-app" build:prod

# After (correct)
RUN pnpm --filter "@beauty-salon-frontend/admin-app" build:prod
RUN pnpm --filter "@beauty-salon-frontend/portal-app" build:prod
RUN pnpm --filter "@beauty-salon-frontend/dashboard-app" build:prod
```

## 📁 Updated Files

- `Dockerfile.backend`
  - Added `--ignore-scripts` to production install
  - Fixed build command to handle different scripts
  - Added NODE_ENV=production
  - Kept explicit COPY paths for reliability
- `Dockerfile.frontend.admin` - Fixed package name
- `Dockerfile.frontend.portal` - Fixed package name
- `Dockerfile.frontend.dashboard` - Fixed package name

## ✅ Verification

### Local Build Test Results

```bash
# Backend production build
docker build -f Dockerfile.backend --target production -t test-backend-prod .
✅ Build successful - All packages and server app built correctly

# Frontend Admin production build
docker build -f Dockerfile.frontend.admin --target runtime -t test-frontend-admin-prod .
✅ Build successful

# Frontend Portal production build
docker build -f Dockerfile.frontend.portal --target runtime -t test-frontend-portal-prod .
✅ Build successful

# Frontend Dashboard production build
docker build -f Dockerfile.frontend.dashboard --target runtime -t test-frontend-dashboard-prod .
✅ Build successful
```

## 🎯 Impact

- ✅ Production Docker builds now complete successfully
- ✅ CI/CD pipeline can deploy to production
- ✅ No unnecessary dev dependencies in production images
- ✅ Correct package resolution for monorepo structure
- ✅ Proper build commands for all components

## 🚀 Next Steps

1. Merge this fix to enable production deployments
2. Monitor CI/CD pipeline for successful builds
3. Verify deployed applications are running correctly

## 📝 Technical Notes

### Why Explicit COPY Paths?
While wildcard COPY might seem simpler, explicit paths provide:
1. **Clear visibility** of what's being copied
2. **Build failure detection** if expected directories don't exist
3. **Better Docker layer caching**
4. **Prevents accidental inclusion** of unwanted files

### Package Naming Convention
- Backend: `@beauty-salon-backend/*`
- Frontend: `@beauty-salon-frontend/*`
- This distinction is critical for pnpm workspace filtering

### Build Script Naming
- Packages use environment-specific builds: `build:dev`, `build:prod`, etc.
- Server app uses simple `build` command
- Important to handle this difference in Docker build commands